### PR TITLE
Remove the gvfs-google, lib32-gstreamer, lib32-gst-plugins-good

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1113,7 +1113,7 @@ exec_install_desktop() {
                 packages+=(sof-firmware) # Need for intel i5 audio
 
                 # Networking & Access
-                packages+=(samba rsync gvfs gvfs-mtp gvfs-smb gvfs-nfs gvfs-afc gvfs-goa gvfs-gphoto2 gvfs-google gvfs-dnssd gvfs-wsdd)
+                packages+=(samba rsync gvfs gvfs-mtp gvfs-smb gvfs-nfs gvfs-afc gvfs-goa gvfs-gphoto2 gvfs-dnssd gvfs-wsdd)
                 packages+=(modemmanager network-manager-sstp networkmanager-l2tp networkmanager-vpnc networkmanager-pptp networkmanager-openvpn networkmanager-openconnect networkmanager-strongswan)
 
                 # Kernel headers
@@ -1132,7 +1132,7 @@ exec_install_desktop() {
                 # Codecs (https://wiki.archlinux.org/title/Codecs_and_containers)
                 packages+=(ffmpeg ffmpegthumbnailer gstreamer gst-libav gst-plugin-pipewire gst-plugins-good gst-plugins-bad gst-plugins-ugly libdvdcss libheif webp-pixbuf-loader opus speex libvpx libwebp)
                 packages+=(a52dec faac faad2 flac jasper lame libdca libdv libmad libmpeg2 libtheora libvorbis libxv wavpack x264 xvidcore libdvdnav libdvdread openh264)
-                [ "$ARCH_OS_MULTILIB_ENABLED" = "true" ] && packages+=(lib32-gstreamer lib32-gst-plugins-good lib32-libvpx lib32-libwebp)
+                [ "$ARCH_OS_MULTILIB_ENABLED" = "true" ] && packages+=(lib32-libvpx lib32-libwebp)
 
                 # Optimization
                 packages+=(gamemode sdl_image)


### PR DESCRIPTION
The packages are generating errors when trying to install because they no longer exist in the Arch Linux AUR.
The gvfs-google generate a error in GNOME installer.